### PR TITLE
fix #9 by sorting versions before xargs echo

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-git ls-remote --tags --refs https://github.com/gleam-lang/gleam "v*" | sed 's;^.*refs/tags/v\(.*\)$;\1;' | grep -vE '^(0.1.0|0.1.1|0.1.2)$' | xargs echo
+git ls-remote --tags --refs https://github.com/gleam-lang/gleam "v*" | sed 's;^.*refs/tags/v\(.*\)$;\1;' | grep -vE '^(0.1.0|0.1.1|0.1.2)$' | sort -V | xargs echo


### PR DESCRIPTION
In accordance with the solution that I outlined in issue #9, I have modified `bin/list-all` so that the output is sorted, and the result of `asdf install gleam latest` is correct:
`bin/list-all` old output:
```
0.10.0 0.10.0-rc1 0.10.0-rc2 0.10.1 0.11.0 0.11.0-rc1 0.11.0-rc2 0.11.0-rc3 0.11.1 0.11.2 0.12.0 0.12.0-rc3 0.12.0-rc4 0.12.1 0.13.0-rc1 0.2.0 0.3.0 0.4.0 0.4.1 0.4.2 0.5.0 0.5.0-rc1 0.5.1 0.6.0 0.6.0-rc1 0.7.0 0.7.0-rc1 0.7.1 0.8.0 0.8.0-rc1 0.8.1 0.9.0 0.9.0-rc1 0.9.1
```

`bin/list-all` new output:
```
0.2.0 0.3.0 0.4.0 0.4.1 0.4.2 0.5.0 0.5.0-rc1 0.5.1 0.6.0 0.6.0-rc1 0.7.0 0.7.0-rc1 0.7.1 0.8.0 0.8.0-rc1 0.8.1 0.9.0 0.9.0-rc1 0.9.1 0.10.0 0.10.0-rc1 0.10.0-rc2 0.10.1 0.11.0 0.11.0-rc1 0.11.0-rc2 0.11.0-rc3 0.11.1 0.11.2 0.12.0 0.12.0-rc3 0.12.0-rc4 0.12.1 0.13.0-rc1
```