### PR TITLE
Add arm64 support for macOS

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -53,6 +53,7 @@ get_variant() {
     Darwin)
       case "$(uname -m)" in
         x86_64) echo macos ;;
+        arm64) echo macos-arm64 ;;
         *) fail "$(uname -m) is not supported on macos" ;;
       esac
       ;;


### PR DESCRIPTION
Since 0.18.0 there is a macOS arm64 build available.