### PR TITLE
Support aarch64 for Linux

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -61,7 +61,7 @@ get_llvm_triplet_variant() {
     Linux)
       case "$(uname -m)" in
         x86_64) echo x86_64-unknown-linux-musl ;;
-        arm64) echo aarch64-unknown-linux-musl ;;
+        aarch64 | arm64) echo aarch64-unknown-linux-musl ;;
         *) fail "$(uname -m) is not supported on linux" ;;
       esac
       ;;


### PR DESCRIPTION
This asdf script failed while trying to install Gleam on my PinePhone.  `uname -m` returns `aarch64` on that device and on my Raspberry Pi 4 as well, so I added "aarch64" to the match for the "aarch-unknown-linux-musl" triple.

I've tested this change on my PinePhone and I was able to install Gleam! :tada:

I read somewhere that "arm64" is an Apple-specific nomenclature, but I have no further evidence for this :shrug: 